### PR TITLE
Add Small Underclock profile for QCS8550 (Ayn Thor verified)

### DIFF
--- a/app/src/main/assets/bundled_profiles/QCS8550.json
+++ b/app/src/main/assets/bundled_profiles/QCS8550.json
@@ -1,24 +1,33 @@
 {
-  "schemaVersion": 1,
-  "socModel": "QCS8550",
-  "profiles": [
-    {
-      "id": "bundled_qcs8550_moderate",
-      "name": "Medium Underclock",
-      "maxFrequencies": {
-        "0": 1555200,
-        "3": 2054400,
-        "7": 2092800
-      }
-    },
-    {
-      "id": "bundled_qcs8550_aggressive",
-      "name": "Large Underclock",
-      "maxFrequencies": {
-        "0": 1459200,
-        "3": 1785600,
-        "7": 1843200
-      }
-    }
-  ]
+    "schemaVersion": 1,
+    "socModel": "QCS8550",
+    "profiles": [
+        {
+            "id": "bundled_qcs8550_small",
+            "name": "Small Underclock",
+            "maxFrequencies": {
+                "0": 1785600,
+                "3": 2323200,
+                "7": 2476800
+            }
+        },
+        {
+            "id": "bundled_qcs8550_moderate",
+            "name": "Medium Underclock",
+            "maxFrequencies": {
+                "0": 1555200,
+                "3": 2054400,
+                "7": 2092800
+            }
+        },
+        {
+            "id": "bundled_qcs8550_aggressive",
+            "name": "Large Underclock",
+            "maxFrequencies": {
+                "0": 1459200,
+                "3": 1785600,
+                "7": 1843200
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Verified on Ayn Thor (QCS8550, policies 0/3/7). The existing Medium and Large profiles work correctly. Adding a Small Underclock (~15% reduction) for mild thermal management while keeping high performance.

Frequencies verified via `scaling_available_frequencies` on device:
- policy0 max: 2016000
- policy3 max: 2707200  
- policy7 max: 2956800

Small Underclock targets:
- policy0: 1785600 (89% of max)
- policy3: 2323200 (86% of max)
- policy7: 2476800 (84% of max)